### PR TITLE
Fixed error message.

### DIFF
--- a/public/app/controllers/loginController.js
+++ b/public/app/controllers/loginController.js
@@ -164,8 +164,8 @@ angular.module('Controllers',["ngRoute", "ngSanitize"])
 						$scope.printErr($scope.errMsg);
 					}
 				});
-			}else{		// blanck nickname 
-				$scope.errMsg = "Enter a nickname.";
+			} else {		// blank username or room name
+				$scope.errMsg = "Please enter both username & room name.";
 				$scope.isErrorReq = true;
 				$scope.printErr($scope.errMsg);
 			}


### PR DESCRIPTION
`Please enter a nickname` is not a clear message. Since it will appear if !room name || !username.
Fixed the message, changed it to `Please enter both username & room name.`