### PR TITLE
(Firefox) Stop Keyboard from Displaying Automatically

### DIFF
--- a/public/app/views/ICE/extensions/ext-shapes.js
+++ b/public/app/views/ICE/extensions/ext-shapes.js
@@ -925,13 +925,6 @@ methodDraw.addExtension("shapes", function () {
 
             $('#tool_shapelib').remove();
 
-            var h = $('#tools_shapelib').height();
-            $('#tools_shapelib').css({
-                'margin-top': -(h / 2) + 75,
-                'margin-left': 3
-            });
-
-
         },
         mouseDown: function (opts) {
 //       var mode = canv.getMode();

--- a/public/app/views/ICE/extensions/ext-shapes.js
+++ b/public/app/views/ICE/extensions/ext-shapes.js
@@ -471,10 +471,6 @@ methodDraw.addExtension("shapes", function () {
 
             var shower = $('#tools_shapelib_show');
 
-            $("#tools_shapelib").css({
-                display: "block"
-            });
-
             var isOpen = false;
 
             loadLibrary('basic');


### PR DESCRIPTION
#215 

- Remove js causing keyboard to be shown by default
- Remove jQuery css that caused poor keyboard alignment on initialization in Firefox 

For both cases, Chrome did not acknowledge the jQuery for some reason and was unaffected by the issues.