### PR TITLE
Added extra symbols for LaTeX editor

### DIFF
--- a/public/app/js/ui.js
+++ b/public/app/js/ui.js
@@ -39,7 +39,6 @@ onMainLoop(function(){
             // Include all tool buttons
             $.each($(".message-tool-button").not(".latex-editor-symbol-button"), function(key, val){
                 toolButtonTotalWidth += $(val).outerWidth();
-                console.log(val);
             });
         }
     }

--- a/public/app/js/ui.js
+++ b/public/app/js/ui.js
@@ -20,12 +20,12 @@ onMainLoop(function(){
     if($("#text-message-input-area").hasClass("latex-editor-shown")) {
         if($(window).width() > 732){
             // Include all tool buttons
-            $.each($(".message-tool-button").not("#send-message-button").not("#equation-editor-button"), function(key, val){
+            $.each($(".message-tool-button").not("#send-message-button").not("#equation-editor-button").not("#text-message-input-extra-symbols .latex-editor-symbol-button"), function(key, val){
                 toolButtonTotalWidth += $(val).outerWidth();
             });
         } else {
             // Include all tool buttons
-            $.each($(".message-tool-button").not("#send-message-button"), function(key, val){
+            $.each($(".message-tool-button").not("#send-message-button").not("#text-message-input-extra-symbols .latex-editor-symbol-button"), function(key, val){
                 toolButtonTotalWidth += $(val).outerWidth();
             });
         }

--- a/public/app/js/ui.js
+++ b/public/app/js/ui.js
@@ -51,12 +51,12 @@ onMainLoop(function(){
             'width': ''
         });
         $("#send-message-button").css({
-            'width': containerWidth - toolButtonTotalWidth - 31
+            'width': containerWidth - toolButtonTotalWidth - 32
         });
     } else {
         $(".latex-editor-symbol-button").hide();
         $("#textArea").css({
-            'width': containerWidth - toolButtonTotalWidth - 31
+            'width': containerWidth - toolButtonTotalWidth - 32
         });
         $("#send-message-button").css({
             'width': ''

--- a/public/app/js/ui.js
+++ b/public/app/js/ui.js
@@ -18,28 +18,45 @@ onMainLoop(function(){
     var containerWidth = $("#text-message-input-area").width();
     var toolButtonTotalWidth = 0;
     if($("#text-message-input-area").hasClass("latex-editor-shown")) {
-        // Exclude the send button
-        $.each($(".message-tool-button").not("#send-message-button"), function(key, val){
-            toolButtonTotalWidth += $(val).outerWidth();
-        });
+        if($(window).width() > 732){
+            // Include all tool buttons
+            $.each($(".message-tool-button").not("#send-message-button").not("#equation-editor-button"), function(key, val){
+                toolButtonTotalWidth += $(val).outerWidth();
+            });
+        } else {
+            // Include all tool buttons
+            $.each($(".message-tool-button").not("#send-message-button"), function(key, val){
+                toolButtonTotalWidth += $(val).outerWidth();
+            });
+        }
     } else {
-        // Include all tool buttons
-        $.each($(".message-tool-button").not(".latex-editor-symbol-button"), function(key, val){
-            toolButtonTotalWidth += $(val).outerWidth();
-        });
+        if($(window).width() > 732){
+            // Include all tool buttons
+            $.each($(".message-tool-button").not(".latex-editor-symbol-button").not("#equation-editor-button"), function(key, val){
+                toolButtonTotalWidth += $(val).outerWidth();
+            });
+        } else {
+            // Include all tool buttons
+            $.each($(".message-tool-button").not(".latex-editor-symbol-button"), function(key, val){
+                toolButtonTotalWidth += $(val).outerWidth();
+                console.log(val);
+            });
+        }
     }
+
+
     if($("#text-message-input-area").hasClass("latex-editor-shown")){
         $(".latex-editor-symbol-button").show();
         $("#textArea").css({
             'width': ''
         });
         $("#send-message-button").css({
-            'width': containerWidth - toolButtonTotalWidth - 32
+            'width': containerWidth - toolButtonTotalWidth - 31
         });
     } else {
         $(".latex-editor-symbol-button").hide();
         $("#textArea").css({
-            'width': containerWidth - toolButtonTotalWidth - 32
+            'width': containerWidth - toolButtonTotalWidth - 31
         });
         $("#send-message-button").css({
             'width': ''

--- a/public/app/styles/chatroom/chat.less
+++ b/public/app/styles/chatroom/chat.less
@@ -175,8 +175,7 @@
       height: 100%;
     }
     #chatroom-footer {
-      height: 20vh;
-      min-height: 200px;
+      height: 175px;
     }   
     div#panel {
       bottom: 0;

--- a/public/app/styles/chatroom/chat.less
+++ b/public/app/styles/chatroom/chat.less
@@ -175,10 +175,16 @@
       height: 100%;
     }
     #chatroom-footer {
-      height: 175px;
+      height: 185px;
     }   
     div#panel {
       bottom: 0;
+    }
+    #text-message-input-extra-symbols {
+      display: block;
+    }
+    #text-message-input-area {
+      padding-bottom: 10px;
     }
   }
 }
@@ -245,7 +251,13 @@ div {
   margin: 0;
 }
 
-#text-message-input-area {
+#text-message-input-extra-symbols {
+  padding-bottom: 10px;
+  display: none;
+}
+
+#text-message-input-area,
+#text-message-input-extra-symbols {
   width: 100%;
   .message-tool-button {
     border: none;
@@ -255,6 +267,13 @@ div {
     padding-left: 5px;
     padding-right: 5px;
     outline: none;
+    &.latex-editor-symbol-button {
+      font-size: 16px;
+      min-width: 30px;
+      color: #7c7c7c;
+      font-weight: bold;
+      font-family: monospace, monospace;
+    }
     &:hover {
       opacity: 1;
     }
@@ -322,7 +341,7 @@ div {
     transition: max-height ease 0.7s;
   }
   .CodeMirror {
-    height: 120px;
+    height: 90px;
   }
   #latex-editor {
     margin-top: 10px;

--- a/public/app/styles/chatroom/chat.less
+++ b/public/app/styles/chatroom/chat.less
@@ -236,9 +236,9 @@ div {
 .box-footer {
   border: none;
   border-top: 1px solid #efefef;
-  padding-bottom: 20px;
-  padding-top: 20px;
-  min-height: 75px;
+  padding-bottom: 5px;
+  padding-top: 5px;
+  min-height: 50px;
 }
 
 .btn {

--- a/public/app/views/chatRoom.html
+++ b/public/app/views/chatRoom.html
@@ -89,6 +89,44 @@
                     <div class="box-footer" id="chatroom-footer">
 
                         <!--Size of this area is modified by JavaScript, registered in ui.js-->
+                        <div id="text-message-input-extra-symbols">
+                            <button class="message-tool-button latex-editor-symbol-button"
+                                    ng-click="latexEditorAddText('=')">
+                                =
+                            </button>
+                            <button class="message-tool-button latex-editor-symbol-button"
+                                    ng-click="latexEditorAddText('+')">
+                                +
+                            </button>
+                            <button class="message-tool-button latex-editor-symbol-button"
+                                    ng-click="latexEditorAddText('-')">
+                                -
+                            </button>
+                            <button class="message-tool-button latex-editor-symbol-button"
+                                    ng-click="latexEditorAddText('*')">
+                                *
+                            </button>
+                            <button class="message-tool-button latex-editor-symbol-button"
+                                    ng-click="latexEditorAddText('/')">
+                                /
+                            </button>
+                            <button class="message-tool-button latex-editor-symbol-button"
+                                    ng-click="latexEditorAddText('^')">
+                                ^
+                            </button>
+                            <button class="message-tool-button latex-editor-symbol-button"
+                                    ng-click="latexEditorAddText('_')">
+                                _
+                            </button>
+                            <button class="message-tool-button latex-editor-symbol-button" id="add-latex-left-bracket-button"
+                                    ng-click="latexEditorAddText('{')">
+                                {
+                            </button>
+                            <button class="message-tool-button latex-editor-symbol-button" id="add-latex-right-bracket-button"
+                                    ng-click="latexEditorAddText('}')">
+                                }
+                            </button>
+                        </div>
                         <div id="text-message-input-area">
                             <button class="message-tool-button" id="latex-button" title="LaTeX Editor"
                                     ng-click="toggleLatexEditor()">
@@ -104,19 +142,11 @@
                             </button>
                             <button class="message-tool-button latex-editor-symbol-button" id="add-latex-wrap-button"
                                     ng-click="latexEditorAddText('$$')">
-                                <img src="/app/images/add-latex-wrap-icon.png" width="20px"/>
+                                $$
                             </button>
                             <button class="message-tool-button latex-editor-symbol-button" id="add-latex-backslash-button"
                                     ng-click="latexEditorAddText('\\')">
-                                <img src="/app/images/add-latex-backslash-icon.png" width="20px"/>
-                            </button>
-                            <button class="message-tool-button latex-editor-symbol-button" id="add-latex-left-bracket-button"
-                                    ng-click="latexEditorAddText('{')">
-                                <img src="/app/images/add-latex-left-bracket-icon.png" width="20px"/>
-                            </button>
-                            <button class="message-tool-button latex-editor-symbol-button" id="add-latex-right-bracket-button"
-                                    ng-click="latexEditorAddText('}')">
-                                <img src="/app/images/add-latex-right-bracket-icon.png" width="20px"/>
+                                \
                             </button>
                             <textarea id="textArea" rows="1" wrap="soft" placeholder="Type Message ..."
                                       ng-model="chatMsg"


### PR DESCRIPTION
* Added more symbols: `=+-*/^_{}`.
* Shinked padding to optimize for small screens.
* Fixed `ui.js` bugs.
![image](https://user-images.githubusercontent.com/7855724/36072635-d05afc3a-0ef0-11e8-9b52-2d245b5b979b.png)
