### PR TITLE
Decrease Message Space and Some CSS Refactoring

### DIFF
--- a/public/app/styles/chatroom/chat-message.less
+++ b/public/app/styles/chatroom/chat-message.less
@@ -5,6 +5,8 @@
 
 .direct-chat-msg {
   display: block;
+  margin-top: 5px;
+  margin-bottom: 0px;
   .chat-img {
     border-radius: 50%;
     float: left;
@@ -16,7 +18,6 @@
   }
   .chat-info {
     display: block;
-    padding-bottom: 5px;
   }
   .chat-timestamp {
     color: #999;
@@ -88,7 +89,7 @@
       max-width: 70%;
       overflow: hidden;
       color: black;
-      margin-top: 10px;
+      margin-top: 5px;
       display: inline-block;
       animation: direct-chat-text-inner-enter 0.2s ease;
       animation-fill-mode: forwards;

--- a/public/app/styles/chatroom/chat.less
+++ b/public/app/styles/chatroom/chat.less
@@ -2,6 +2,9 @@
  * Any styles related to chat.
  */
 
+ @latex-editor-hidden: 50px;
+ @latex-editor-shown: 185px;
+
 .btn-flat {
   label {
     font-weight: normal;
@@ -170,12 +173,12 @@
 #direct-chat-container {
   border: none;
   &.latex-editor-shown {
-    padding-bottom: 200px;
+    padding-bottom: @latex-editor-shown;
     #chat-body-div {
       height: 100%;
     }
     #chatroom-footer {
-      height: 185px;
+      height: @latex-editor-shown;
     }   
     div#panel {
       bottom: 0;
@@ -202,7 +205,7 @@
 #direct-chat-container {
   height: 100%;
   height: 100vh;
-  padding-bottom: 75px;
+  padding-bottom: @latex-editor-hidden;
 }
 
 div {
@@ -236,14 +239,6 @@ div {
 
 #textArea {
   border: none;
-}
-
-.box-footer {
-  border: none;
-  border-top: 1px solid #efefef;
-  padding-bottom: 5px;
-  padding-top: 5px;
-  min-height: 50px;
 }
 
 .btn {
@@ -329,6 +324,11 @@ div {
   position: absolute;
   bottom: 0;
   left: 0;
+  border: none;
+  border-top: 1px solid #efefef;
+  padding-bottom: 5px;
+  padding-top: 5px;
+  min-height: @latex-editor-hidden;
 }
 
 /* Chat latex editor */
@@ -356,10 +356,6 @@ div {
 }
 
 @media screen and (max-width: 732px) {
-  #chatroom-footer {
-    position: fixed;
-  }
-
   #chat-body-div {
     overflow-y: scroll;
     height: 100%;
@@ -369,7 +365,7 @@ div {
 
   #direct-chat-container {
     &.latex-editor-shown {
-      padding-bottom: 200px;
+      padding-bottom: @latex-editor-shown;
       #chat-body-div {
         max-height: unset;
       }


### PR DESCRIPTION
- Decrease space between messages. 
- Relate bottom padding of chat body and height of chatroom footer with variables. 
- Move legacy .box-footer styles to newer #chatroom-footer css.