### PR TITLE
Update scrolling to bottom to not activate if deleting messages.

### DIFF
--- a/public/app/controllers/chatRoomController.js
+++ b/public/app/controllers/chatRoomController.js
@@ -8,12 +8,14 @@ angular.module('Controllers')
       scrollBottom: "="
     },
     link: function (scope, element) {
-      scope.$watchCollection('scrollBottom', function (newValue) {
-        if (newValue)
-        {
-          setTimeout(function() {
-			  $(element).scrollTop($(element)[0].scrollHeight);
-		  }, 100);
+      scope.$watchCollection('scrollBottom', function (newValue, oldValue) {
+        // if messages are deleted do not scroll to bottom
+        if (oldValue.length <= newValue.length) {
+          if (newValue) {
+              setTimeout(function() {
+                  $(element).scrollTop($(element)[0].scrollHeight);
+              }, 100);
+          }
         }
       });
     }


### PR DESCRIPTION
If an instructor needs to delete many old messages, they can delete them without needing to keep scrolling back up.