### PR TITLE
Fix console errors about accessing undefined properties when cycling through symbols

### DIFF
--- a/public/app/views/ICE/src/svgcanvas.js
+++ b/public/app/views/ICE/src/svgcanvas.js
@@ -247,7 +247,7 @@ keyHash["r"] = ['r', 'R', '211D', '211C', '3C1', '221A'];
 keyHash["s"] = ['s', 'S', '2211', '3C3', '2286', '2282', '3C2'];
 keyHash["t"] = ['t', 'T', '3B8', '3C4', 'D7', '3D1', '398'];
 keyHash["u"] = ['u', 'U', '222A', '2229', '3C5'];
-keyHash["v"] = ['v', 'V', '2228', '8743'];
+keyHash["v"] = ['v', 'V', '2228'];
 keyHash["w"] = ['w', 'W'];
 keyHash["x"] = ['x', 'X', '3C7', '3BE', '39E'];
 keyHash["y"] = ['y', 'Y'];
@@ -10030,8 +10030,12 @@ var moveCursorAbs = this.moveCursorAbs;
     }
 
     if (!newChar) {
+      if (shortcuts) {
         shortcutIndex++;
-        if (shortcutIndex >= shortcuts.length) shortcutIndex = 0;
+        if (shortcutIndex >= shortcuts.length) {
+          shortcutIndex = 0;
+        }
+      }
     } else {
         lastKeyPress = key;
         shortcutIndex = 0;
@@ -10120,10 +10124,12 @@ var moveCursorAbs = this.moveCursorAbs;
       if(getBBox(newText).x != math_cursorB.x) {
       }
     } else {
-        if (shortcuts[shortcutIndex].length == 1) {
-          newText.textContent = shortcuts[shortcutIndex];
-        } else {
-          newText.textContent = String.fromCharCode("0x"+shortcuts[shortcutIndex]); 
+        if (shortcuts) {
+          if (shortcuts[shortcutIndex].length == 1) {
+            newText.textContent = shortcuts[shortcutIndex];
+          } else {
+            newText.textContent = String.fromCharCode("0x"+shortcuts[shortcutIndex]);
+          }
         }
     }
     //console.log(newText);

--- a/public/app/views/ICE/src/svgcanvas.js
+++ b/public/app/views/ICE/src/svgcanvas.js
@@ -10101,7 +10101,7 @@ var moveCursorAbs = this.moveCursorAbs;
     if(selectedElements.length > 0) {
       clearSelection();
     }
-    if (newChar) {
+    if (newChar || !shortcuts) {
     	newText = addSvgElementFromJson({
       element: 'text',
     	curStyles: true,


### PR DESCRIPTION
- also removed a random Chinese character binded to the letter v. 

This issue is related to the cycling of characters. This cycling does not allow users to enter the same key twice as one would expect for keys with multiple bindings. I have also changed it so keys which do not have multiple bindings (refer to keyHash variable in svgcanvas.js for all mappings) can now be output consecutively if a different character was input previously. (e.g. previously aA would not output another A if "shift+A" was inputted.)
