### PR TITLE
Update Gulp to add more precise workflow to javascript watchers. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chatRoom",
   "scripts": {
-    "start": "node app.js",
+    "start": "gulp deploy && node app.js",
     "test": "mocha",
     "dev": "node app.js & gulp dev",
     "deploy": "gulp deploy"


### PR DESCRIPTION
- If you are working on legacy code that is not tied to any bundles, the watcher for bundled code will not trigger and will reload the page immediately instead. This will save time from unnecessary compilation.

- Update `npm start` to additionally compile the code and start the app. It will now be more convenient if you just want to run the app locally on port 8080.