### PR TITLE
Re-enable snapping feature.

### DIFF
--- a/public/app/views/ICE/src/method-draw.js
+++ b/public/app/views/ICE/src/method-draw.js
@@ -45,7 +45,7 @@ var SOTP = 0;
       initTool: 'select',
       wireframe: false,
       colorPickerCSS: false,
-      gridSnapping: false,   //**MDP
+      gridSnapping: true,   //**MDP
       gridColor: "#000",
       baseUnit: 'px',
       snappingStep: 10,


### PR DESCRIPTION
Test this feature by clicking and dragging almost anything. You will find that it requires a certain amount of mouse movement before the selected item moves. You can modify the existing property `snappingStep` of `curConfig` from `method-draw.js` to a large number (such as 50) to experience a more noticeable change.

(Aside: Moving the pair of svg brackets one snappingStep level up will recognize the equation from #288 correctly.)